### PR TITLE
Update alpine version to the latest one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine
 
 LABEL "com.github.actions.name"="Create Zip File"
 LABEL "com.github.actions.description"="Create a zip file containing specific files from your repository"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:latest
 
 LABEL "com.github.actions.name"="Create Zip File"
 LABEL "com.github.actions.description"="Create a zip file containing specific files from your repository"


### PR DESCRIPTION
Hi @montudor,

I've noticed that the alpine version 3.10.1 does not exist anymore. As a result, the GitHub workflow fails.

ref. https://hub.docker.com/_/alpine?tab=tags


Thanks